### PR TITLE
fix: truncated LWT message

### DIFF
--- a/src/helpers/mqtt/MQTTUplink.h
+++ b/src/helpers/mqtt/MQTTUplink.h
@@ -94,7 +94,7 @@ private:
     char* token;
     char client_id[48];
     char status_topic[128];
-    char offline_payload[256];
+    char offline_payload[512];
   };
 #endif
 


### PR DESCRIPTION
That JSON includes eight fields: status, timestamp (26 chars), origin (up to 80 chars, escaped), origin_id (64-char hex public key), model (up to 40 chars), firmware_version, radio (up to 48 chars), and client_version (up to 96 chars). 
In the worst case, the formatted string approaches ~490 bytes.

Even in a typical scenario—consisting of the JSON skeleton and status (126 chars), origin (~20 chars), origin_id (64 chars), model (~16 chars), firmware_version (~7 chars), radio (~16 chars), and client_version (20 chars)—the formatted string is around 269 chars. This causes snprintf() to silently truncate the payload, resulting in malformed JSON.

Increasing to 512 covers all possible cases.
Alternative minimum can be 320 chars. 